### PR TITLE
Add Jinja2 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a minimal proof-of-concept with a Python-based API serv
 - **server/** – FastAPI application exposing a `/generate` endpoint to transform chat prompts into Swift code via the OpenAI API.
 - **scripts/build.sh** – Example shell script to run `xcodebuild` on macOS. Requires Xcode command-line tools.
 - **requirements.txt** – Python dependencies for the API server.
+- Jinja2 templates power the optional web UI and are included in `requirements.txt`.
 
 ### Running the API
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ uvicorn==0.29.0
 openai==1.9.0
 pydantic==2.5.2
 httpx==0.24.1
+jinja2==3.1.4
 pytest==8.3.5


### PR DESCRIPTION
## Summary
- pin `jinja2==3.1.4` in requirements
- mention Jinja2 in README for the optional UI

## Testing
- `pytest -q`